### PR TITLE
chore: Set publishConfig access to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "/scripts/binaries.mjs",
     "/scripts/check-build.mjs",
     "/scripts/copy-target.mjs"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
This is required to publish on npm:
https://github.com/getsentry/publish/actions/runs/15612164742/job/43975488526#step:12:237