### PR TITLE
feat: Allow disabling of watchdog tracking per thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- feat: Allow disabling of watchdog tracking per thread (#11)
+
 ## 0.1.1
 
 - meta: Improve `README.md`, `package.json` metadata and add `LICENSE` (#10)

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ type StackFrame = {
 
 interface Native {
   registerThread(threadName: string): void;
-  threadPoll(state?: object): void;
+  threadPoll(state?: object, disableLastSeen?: boolean): void;
   captureStackTrace<S = unknown>(): Record<string, Thread<S>>;
   getThreadsLastSeen(): Record<string, number>;
 }
@@ -187,10 +187,11 @@ export function registerThread(threadName: string = String(threadId)): void {
  * Tells the native module that the thread is still running and updates the state.
  *
  * @param state Optional state to pass to the native module.
+ * @param disableLastSeen If true, disables the last seen tracking for this thread.
  */
-export function threadPoll(state?: object): void {
-  if (typeof state === 'object') {
-    native.threadPoll(state);
+export function threadPoll(state?: object, disableLastSeen?: boolean): void {
+  if (typeof state === 'object' || disableLastSeen) {
+    native.threadPoll(state, disableLastSeen);
   } else {
     native.threadPoll();
   }

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -89,4 +89,13 @@ describe('e2e Tests', { timeout: 20000 }, () => {
 
     expect(stacks['2'].frames.length).toEqual(1);
   });
+
+  test('can be disabled', { timeout: 20000 }, () => {
+    const testFile = join(__dirname, 'stalled-disabled.js');
+    const result = spawnSync('node', [testFile]);
+
+    expect(result.status).toEqual(0);
+
+    expect(result.stdout.toString()).toContain('complete');
+  });
 });

--- a/test/stalled-disabled.js
+++ b/test/stalled-disabled.js
@@ -1,0 +1,24 @@
+const { Worker } = require('node:worker_threads');
+const { longWork } = require('./long-work.js');
+const { registerThread, threadPoll } = require('@sentry-internal/node-native-stacktrace');
+
+registerThread();
+
+setInterval(() => {
+  threadPoll({ some_property: 'some_value' }, true);
+}, 200).unref();
+
+const watchdog = new Worker('./test/stalled-watchdog.js');
+watchdog.on('exit', () => process.exit(0));
+
+const worker = new Worker('./test/worker-do-nothing.js');
+
+setTimeout(() => {
+  longWork();
+
+  setTimeout(() => {
+    console.log('complete');
+    process.exit(0);
+  }, 1000);
+}, 2000);
+


### PR DESCRIPTION
This PR adds the ability to disable the "last seen tracking" from any thread via an optional second parameter in the `threadPoll` function.