### PR TITLE
fix: Correct the Electron warning log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+- fix: Correct the Electron warning log message
+
 ## 0.2.0
 
 - feat: Allow disabling of watchdog tracking per thread (#11)

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ function getNativeModule(): Native {
       return require('../build/Release/stack-trace.node');
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.warn('The \'@sentry/profiling-node\' binary could not be found. Use \'@electron/rebuild\' to ensure the native module is built for Electron.');
+      console.warn('The \'@sentry-internal/node-native-stacktrace\' binary could not be found. Use \'@electron/rebuild\' to ensure the native module is built for Electron.');
       throw e;
     }
   }


### PR DESCRIPTION
I was testing Electron and noticed the warning message was wrong!