### PR TITLE
ci: Use Musl asset from Sentry storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Setup Musl
         if: contains(matrix.container, 'alpine')
         run: |
-          curl -OL https://musl.cc.timfish.dev/aarch64-linux-musl-cross.tgz
+          curl -OL https://storage.googleapis.com/sentry-dev-infra-build-assets/aarch64-linux-musl-cross.tgz
           tar -xzvf aarch64-linux-musl-cross.tgz
           $(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc --version
 


### PR DESCRIPTION
Use a Sentry storage assets rather than the proxy.