### PR TITLE
ref: rename node native stacktrace package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,19 @@ jobs:
         if: matrix.arch != 'arm64'
         run: yarn build:bindings:configure
 
+      - name: Remove unsupported Node LTO flags
+        if: matrix.os == 'windows-2022' && matrix.node == 26 && matrix.arch != 'arm64'
+        shell: pwsh
+        run: |
+          $projectFiles = Get-ChildItem -Path build -Filter *.vcxproj -Recurse
+          foreach ($file in $projectFiles) {
+            $content = Get-Content -Raw -Path $file.FullName
+            $content = $content -replace '(?i)\s*-flto=(thin|full)', ''
+            $content = $content -replace '(?i)\s*/flto=(thin|full)', ''
+            $content = $content -replace '(?i)\s*/opt:lldltojobs=\d+', ''
+            Set-Content -Path $file.FullName -Value $content -NoNewline
+          }
+
       - name: Configure node-gyp (arm64, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})
         if: matrix.arch == 'arm64' && matrix.target_platform != 'darwin'
         run: yarn build:bindings:configure:arm64

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `@sentry-internal/node-native-stacktrace`
+# `@sentry/node-native-stacktrace`
 
 A native Node.js module that can capture JavaScript stack traces for registered
 main or worker threads from any other thread, even if event loops are blocked.
@@ -22,7 +22,7 @@ feature.
 In your main thread or worker threads:
 
 ```ts
-import { registerThread } from "@sentry-internal/node-native-stacktrace";
+import { registerThread } from "@sentry/node-native-stacktrace";
 
 // Register this thread for monitoring
 registerThread();
@@ -31,7 +31,7 @@ registerThread();
 ### 2. Capture stack traces from any thread
 
 ```ts
-import { captureStackTrace } from "@sentry-internal/node-native-stacktrace";
+import { captureStackTrace } from "@sentry/node-native-stacktrace";
 
 // Capture stack traces from all registered threads
 const stacks = captureStackTrace();
@@ -115,7 +115,7 @@ Send regular heartbeats:
 import {
   registerThread,
   threadPoll,
-} from "@sentry-internal/node-native-stacktrace";
+} from "@sentry/node-native-stacktrace";
 import { AsyncLocalStorage } from "node:async_hooks";
 
 // Create async local storage for state tracking
@@ -140,7 +140,7 @@ Monitor all registered threads from a dedicated thread:
 import {
   captureStackTrace,
   getThreadsLastSeen,
-} from "@sentry-internal/node-native-stacktrace";
+} from "@sentry/node-native-stacktrace";
 
 const THRESHOLD = 1000; // 1 second
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sentry-internal/node-native-stacktrace",
+  "name": "@sentry/node-native-stacktrace",
   "version": "0.5.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ function getNativeModule(): Native {
       return require('../build/Release/stack-trace.node');
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.warn('The \'@sentry-internal/node-native-stacktrace\' binary could not be found. Use \'@electron/rebuild\' to ensure the native module is built for Electron.');
+      console.warn('The \'@sentry/node-native-stacktrace\' binary could not be found. Use \'@electron/rebuild\' to ensure the native module is built for Electron.');
       throw e;
     }
   }

--- a/test/async-storage.mjs
+++ b/test/async-storage.mjs
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { Worker } from 'node:worker_threads';
-import { registerThread } from '@sentry-internal/node-native-stacktrace';
+import { registerThread } from '@sentry/node-native-stacktrace';
 import { longWork } from './long-work.js';
 
 const asyncLocalStorage = new AsyncLocalStorage();

--- a/test/package.json.template
+++ b/test/package.json.template
@@ -2,6 +2,6 @@
   "name": "node-native-stacktrace-test",
   "license": "MIT",
   "dependencies": {
-    "@sentry-internal/node-native-stacktrace": "{{path}}"
+    "@sentry/node-native-stacktrace": "{{path}}"
   }
 }

--- a/test/stack-traces.js
+++ b/test/stack-traces.js
@@ -1,6 +1,6 @@
 const { Worker } = require('node:worker_threads');
 const { longWork } = require('./long-work.js');
-const { registerThread } = require('@sentry-internal/node-native-stacktrace');
+const { registerThread } = require('@sentry/node-native-stacktrace');
 
 registerThread();
 

--- a/test/stalled-disabled.js
+++ b/test/stalled-disabled.js
@@ -1,7 +1,7 @@
 const { Worker } = require('node:worker_threads');
 const { AsyncLocalStorage } = require('node:async_hooks');
 const { longWork } = require('./long-work.js');
-const { registerThread, threadPoll } = require('@sentry-internal/node-native-stacktrace');
+const { registerThread, threadPoll } = require('@sentry/node-native-stacktrace');
 
 const asyncLocalStorage = new AsyncLocalStorage();
 asyncLocalStorage.enterWith({ some_property: 'some_value' });

--- a/test/stalled-forever.js
+++ b/test/stalled-forever.js
@@ -1,5 +1,5 @@
 const { Worker } = require('node:worker_threads');
-const { registerThread, threadPoll } = require('@sentry-internal/node-native-stacktrace');
+const { registerThread, threadPoll } = require('@sentry/node-native-stacktrace');
 
 registerThread();
 

--- a/test/stalled-watchdog.js
+++ b/test/stalled-watchdog.js
@@ -1,4 +1,4 @@
-const { captureStackTrace, getThreadsLastSeen } = require('@sentry-internal/node-native-stacktrace');
+const { captureStackTrace, getThreadsLastSeen } = require('@sentry/node-native-stacktrace');
 
 const THRESHOLD = 500; // 1 second
 

--- a/test/stalled.js
+++ b/test/stalled.js
@@ -1,6 +1,6 @@
 const { Worker } = require('node:worker_threads');
 const { longWork } = require('./long-work.js');
-const { registerThread, threadPoll } = require('@sentry-internal/node-native-stacktrace');
+const { registerThread, threadPoll } = require('@sentry/node-native-stacktrace');
 
 registerThread();
 

--- a/test/watchdog.js
+++ b/test/watchdog.js
@@ -1,4 +1,4 @@
-const { captureStackTrace } = require('@sentry-internal/node-native-stacktrace');
+const { captureStackTrace } = require('@sentry/node-native-stacktrace');
 
 setTimeout(() => {
     console.log(JSON.stringify(captureStackTrace()));

--- a/test/worker-do-nothing.js
+++ b/test/worker-do-nothing.js
@@ -1,4 +1,4 @@
-const { registerThread, threadPoll } = require('@sentry-internal/node-native-stacktrace');
+const { registerThread, threadPoll } = require('@sentry/node-native-stacktrace');
 
 registerThread();
 

--- a/test/worker-forever.js
+++ b/test/worker-forever.js
@@ -1,5 +1,5 @@
 const { foreverWork } = require('./long-work');
-const { registerThread, threadPoll } = require('@sentry-internal/node-native-stacktrace');
+const { registerThread, threadPoll } = require('@sentry/node-native-stacktrace');
 
 registerThread();
 

--- a/test/worker.js
+++ b/test/worker.js
@@ -1,5 +1,5 @@
 const { longWork } = require('./long-work');
-const { registerThread } = require('@sentry-internal/node-native-stacktrace');
+const { registerThread } = require('@sentry/node-native-stacktrace');
 
 registerThread();
 


### PR DESCRIPTION
Renames the published package from `@sentry-internal/node-native-stacktrace` to `@sentry/node-native-stacktrace` and updates docs/test imports.

CI note: also strips unsupported Node 26 Windows LTO flags from the generated node-gyp project. `node-version: 26` now resolves to Node 26.3.0, whose headers add `/opt:lldltojobs`; MSVC rejects that option when compiling this addon.

This should be released before `getsentry/sentry-javascript` switches its node-native dependency.

Refs getsentry/sentry-javascript#21366