### PR TITLE
fix: Remove V8_DEPRECATION_WARNINGS define to fix build with GCC <= 12

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,10 @@
     {
       "target_name": "stack-trace",
       "sources": [ "module.cc" ],
+      # With V8_DEPRECATION_WARNINGS defined, the class-level V8_DEPRECATED
+      # annotations in the V8 15+ (Electron >= 43) headers expand to a mix of
+      # C++11 and GNU attributes that GCC <= 12 cannot parse
+      "defines!": [ "V8_DEPRECATION_WARNINGS=1" ],
       "conditions": [
         ["OS=='win'", {
           "defines": [


### PR DESCRIPTION
Building this module against the Electron ≥ 43 headers fails on Linux with stock GCC on Ubuntu 22.04 / Debian 12 (see the failing `E2E Tests (ubuntu-22.04, 43.2.0, *)` jobs in getsentry/sentry-electron#1398):

```
/home/runner/.electron-gyp/43.2.0/include/node/v8config.h:854:20: error: expected identifier before '__attribute__'
  854 | # define V8_EXPORT __attribute__((visibility("default")))
/home/runner/.electron-gyp/43.2.0/include/node/v8-primitive.h:658:4: error: expected primary-expression before 'public'
```

Electron 43 ships V8 15.0, where `v8::String::Value` now carries a class-level deprecation ([v8-primitive.h:655](https://github.com/v8/v8/blob/main/include/v8-primitive.h#L655)):

```cpp
class V8_DEPRECATED(
    "Prefer using String::ValueView if you can, or string->Write to a "
    "buffer if you cannot.") V8_EXPORT Value {
```

node-gyp's `addon.gypi` compiles all addons with `-DV8_DEPRECATION_WARNINGS=1`, so this expands to `class [[deprecated("…")]] __attribute__((visibility("default"))) Value` — a C++11 attribute mixed with a GNU attribute in a class head, which GCC ≤ 12 cannot parse (in either attribute order). GCC 13+ and clang parse it fine. The same declaration is still on V8 `main`, so this will also hit Node.js once it ships V8 15.

This PR strips the `V8_DEPRECATION_WARNINGS=1` define via a `defines!` exclusion so the `V8_DEPRECATED` macros expand to nothing, restoring builds on GCC ≤ 12. The trade-off is that builds of this module no longer emit V8 API deprecation warnings.

Verified in Docker (`node:20-bookworm`, GCC 12.2) with `node-gyp rebuild --target=43.2.0 --dist-url=https://electronjs.org/headers`: reproduces the exact error before this change, builds cleanly after.